### PR TITLE
Fix lambda deploy bug

### DIFF
--- a/src/util/ekkoFunction.js
+++ b/src/util/ekkoFunction.js
@@ -20,7 +20,7 @@ const deploy = async (fileName) => {
       ZipFile: zipContents,
     },
     FunctionName: fileName,
-    Handler: `${fileName}.handler`,
+    Handler: `${fileName}/index.handler`,
     Role: LAMBDA_ROLE_ARN,
     Runtime: "nodejs14.x",
     Tags: { service: "ekko" },


### PR DESCRIPTION
Updated function handler to trigger the index.js file on Lambda invocation.
Couldn't figure out how to not have a nested folder, but I had the same issue when manually uploading a zip file.